### PR TITLE
Switch from isberlinhappytoday.com to isberlinhappy.jdenn.es

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 The answer to the question of whether Berlin is [happy](http://whenyouliveinberlin.tumblr.com/post/44138613156/when-its-sunny-for-more-than-5-minutes) is closely related to the weather.
 
-This phenomenon is probably true of most places in the world, but this little app is just for Berlin: http://isberlinhappytoday.com
+This phenomenon is probably true of most places in the world, but this little app is just for Berlin: http://isberlinhappy.jdenn.es
 
 You can get the answer as JSON, by setting the `Accept` header value to `application/json` when making a request:
 
 ```sh
-$ curl -H "Accept: application/json" "http://www.isberlinhappytoday.com"
+$ curl -H "Accept: application/json" http://isberlinhappy.jdenn.es
 {"happy":"Yes!","text":"Fair","temp_c":23,"temp_f":73}
 ```
 

--- a/views/_google_analytics.haml
+++ b/views/_google_analytics.haml
@@ -1,7 +1,7 @@
 :javascript
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-40461456-1']);
-  _gaq.push(['_setDomainName', 'isberlinhappytoday.com']);
+  _gaq.push(['_setDomainName', 'isberlinhappy.jdenn.es']);
   _gaq.push(['_trackPageview']);
 
   (function() {


### PR DESCRIPTION
I'm moving this from its own domain at http://isberlinhappytoday.com, to http://isberlinhappy.jdenn.es instead.
